### PR TITLE
Split out the routing from the plugin in the hapi code

### DIFF
--- a/dist/hapi.js
+++ b/dist/hapi.js
@@ -3,6 +3,8 @@
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
+exports.getRoute = getRoute;
+exports.postRoute = postRoute;
 exports.hapiPlugin = hapiPlugin;
 
 var _joi = require('joi');
@@ -19,60 +21,68 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
 
 function _interopRequireWildcard(obj) { if (obj && obj.__esModule) { return obj; } else { var newObj = {}; if (obj != null) { for (var key in obj) { if (Object.prototype.hasOwnProperty.call(obj, key)) newObj[key] = obj[key]; } } newObj.default = obj; return newObj; } }
 
-function hapiPlugin(options) {
-  var receiver = new _receiver.Receiver(options);
-  function plugin(server, _, next) {
-    var baseGet = (0, _deepAssign2.default)({}, {
-      method: 'GET',
-      path: '/upload',
-      handler: function handler(request, reply) {
-        reply().code(receiver.testChunk(request.query));
-      },
-      config: {
-        validate: {
-          query: {
-            flowChunkNumber: Joi.number().integer(),
-            flowChunkSize: Joi.number().integer(),
-            flowTotalSize: Joi.number().integer(),
-            flowIdentifier: Joi.string(),
-            flowFilename: Joi.string(),
-            flowCurrentChunkSize: Joi.number().integer().optional(),
-            flowTotalChunks: Joi.number().integer().optional(),
-            flowRelativePath: Joi.string().optional()
-          }
+function getRoute(receiver) {
+  return {
+    method: 'GET',
+    path: '/upload',
+    handler: function handler(request, reply) {
+      reply().code(receiver.testChunk(request.query));
+    },
+    config: {
+      validate: {
+        query: {
+          flowChunkNumber: Joi.number().integer(),
+          flowChunkSize: Joi.number().integer(),
+          flowTotalSize: Joi.number().integer(),
+          flowIdentifier: Joi.string(),
+          flowFilename: Joi.string(),
+          flowCurrentChunkSize: Joi.number().integer().optional(),
+          flowTotalChunks: Joi.number().integer().optional(),
+          flowRelativePath: Joi.string().optional()
         }
       }
-    }, options.getOptions || {});
+    }
+  };
+}
 
-    var basePost = (0, _deepAssign2.default)({}, {
-      method: 'POST',
-      path: '/upload',
-      handler: function handler(request, reply) {
-        receiver.handleChunk(request.payload, request.payload.file).then(function () {
-          return reply().code(200);
-        });
+function postRoute(receiver) {
+  return {
+    method: 'POST',
+    path: '/upload',
+    handler: function handler(request, reply) {
+      receiver.handleChunk(request.payload, request.payload.file).then(function () {
+        return reply().code(200);
+      });
+    },
+    config: {
+      payload: {
+        maxBytes: 209715200,
+        output: 'stream',
+        parse: true
       },
-      config: {
+      validate: {
         payload: {
-          maxBytes: 209715200,
-          output: 'stream',
-          parse: true
-        },
-        validate: {
-          payload: {
-            file: Joi.any().required(),
-            flowChunkNumber: Joi.number().integer(),
-            flowChunkSize: Joi.number().integer(),
-            flowTotalSize: Joi.number().integer(),
-            flowIdentifier: Joi.string(),
-            flowFilename: Joi.string(),
-            flowCurrentChunkSize: Joi.number().integer().optional(),
-            flowTotalChunks: Joi.number().integer().optional(),
-            flowRelativePath: Joi.string().optional()
-          }
+          file: Joi.any().required(),
+          flowChunkNumber: Joi.number().integer(),
+          flowChunkSize: Joi.number().integer(),
+          flowTotalSize: Joi.number().integer(),
+          flowIdentifier: Joi.string(),
+          flowFilename: Joi.string(),
+          flowCurrentChunkSize: Joi.number().integer().optional(),
+          flowTotalChunks: Joi.number().integer().optional(),
+          flowRelativePath: Joi.string().optional()
         }
       }
-    }, options.postOptions || {});
+    }
+  };
+}
+
+function hapiPlugin(options) {
+  var receiver = options.receiver || new _receiver.Receiver(options);
+  function plugin(server, _, next) {
+    var baseGet = (0, _deepAssign2.default)({}, getRoute(receiver), options.getOptions || {});
+
+    var basePost = (0, _deepAssign2.default)({}, postRoute(receiver), options.postOptions || {});
 
     server.route([baseGet, basePost]);
     next();

--- a/dist/index.js
+++ b/dist/index.js
@@ -3,11 +3,15 @@
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
-exports.Receiver = exports.hapiPlugin = undefined;
+exports.Receiver = exports.hapi = undefined;
 
 var _receiver = require('./receiver');
 
 var _hapi = require('./hapi');
 
-exports.hapiPlugin = _hapi.hapiPlugin;
+var hapi = _interopRequireWildcard(_hapi);
+
+function _interopRequireWildcard(obj) { if (obj && obj.__esModule) { return obj; } else { var newObj = {}; if (obj != null) { for (var key in obj) { if (Object.prototype.hasOwnProperty.call(obj, key)) newObj[key] = obj[key]; } } newObj.default = obj; return newObj; } }
+
+exports.hapi = hapi;
 exports.Receiver = _receiver.Receiver;

--- a/dist/receiver.js
+++ b/dist/receiver.js
@@ -33,8 +33,6 @@ function _interopRequireWildcard(obj) { if (obj && obj.__esModule) { return obj;
 
 function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError("Cannot call a class as a function"); } }
 
-// import { handleError } from './handleError';
-
 var Receiver = exports.Receiver = function () {
   function Receiver() {
     var opts = arguments.length > 0 && arguments[0] !== undefined ? arguments[0] : {};

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "flange",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "A node.js server plugin for receiving flow.js uploads",
   "main": "dist/index.js",
   "scripts": {

--- a/src/hapi.js
+++ b/src/hapi.js
@@ -2,65 +2,74 @@ import * as Joi from 'joi';
 import { Receiver } from './receiver';
 import deepAssign from 'deep-assign';
 
+export function getRoute(receiver) {
+  return {
+    method: 'GET',
+    path: '/upload',
+    handler: (request, reply) => {
+      reply().code(receiver.testChunk(request.query));
+    },
+    config: {
+      validate: {
+        query: {
+          flowChunkNumber: Joi.number().integer(),
+          flowChunkSize: Joi.number().integer(),
+          flowTotalSize: Joi.number().integer(),
+          flowIdentifier: Joi.string(),
+          flowFilename: Joi.string(),
+          flowCurrentChunkSize: Joi.number().integer().optional(),
+          flowTotalChunks: Joi.number().integer().optional(),
+          flowRelativePath: Joi.string().optional(),
+        },
+      },
+    },
+  };
+}
+
+export function postRoute(receiver) {
+  return {
+    method: 'POST',
+    path: '/upload',
+    handler: (request, reply) => {
+      receiver.handleChunk(request.payload, request.payload.file)
+      .then(() => reply().code(200));
+    },
+    config: {
+      payload: {
+        maxBytes: 209715200,
+        output: 'stream',
+        parse: true,
+      },
+      validate: {
+        payload: {
+          file: Joi.any().required(),
+          flowChunkNumber: Joi.number().integer(),
+          flowChunkSize: Joi.number().integer(),
+          flowTotalSize: Joi.number().integer(),
+          flowIdentifier: Joi.string(),
+          flowFilename: Joi.string(),
+          flowCurrentChunkSize: Joi.number().integer().optional(),
+          flowTotalChunks: Joi.number().integer().optional(),
+          flowRelativePath: Joi.string().optional(),
+        },
+      },
+    },
+  };
+}
+
+
 export function hapiPlugin(options) {
-  const receiver = new Receiver(options);
+  const receiver = options.receiver || new Receiver(options);
   function plugin(server, _, next) {
     const baseGet = deepAssign(
       {},
-      {
-        method: 'GET',
-        path: '/upload',
-        handler: (request, reply) => {
-          reply().code(receiver.testChunk(request.query));
-        },
-        config: {
-          validate: {
-            query: {
-              flowChunkNumber: Joi.number().integer(),
-              flowChunkSize: Joi.number().integer(),
-              flowTotalSize: Joi.number().integer(),
-              flowIdentifier: Joi.string(),
-              flowFilename: Joi.string(),
-              flowCurrentChunkSize: Joi.number().integer().optional(),
-              flowTotalChunks: Joi.number().integer().optional(),
-              flowRelativePath: Joi.string().optional(),
-            },
-          },
-        },
-      },
+      getRoute(receiver),
       options.getOptions || {}
     );
 
     const basePost = deepAssign(
       {},
-      {
-        method: 'POST',
-        path: '/upload',
-        handler: (request, reply) => {
-          receiver.handleChunk(request.payload, request.payload.file)
-          .then(() => reply().code(200));
-        },
-        config: {
-          payload: {
-            maxBytes: 209715200,
-            output: 'stream',
-            parse: true,
-          },
-          validate: {
-            payload: {
-              file: Joi.any().required(),
-              flowChunkNumber: Joi.number().integer(),
-              flowChunkSize: Joi.number().integer(),
-              flowTotalSize: Joi.number().integer(),
-              flowIdentifier: Joi.string(),
-              flowFilename: Joi.string(),
-              flowCurrentChunkSize: Joi.number().integer().optional(),
-              flowTotalChunks: Joi.number().integer().optional(),
-              flowRelativePath: Joi.string().optional(),
-            },
-          },
-        },
-      },
+      postRoute(receiver),
       options.postOptions || {}
     );
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,7 @@
 import { Receiver } from './receiver';
-import { hapiPlugin } from './hapi';
+import * as hapi from './hapi';
 
 export {
-  hapiPlugin,
+  hapi,
   Receiver,
 };

--- a/src/receiver.js
+++ b/src/receiver.js
@@ -4,8 +4,6 @@ import * as path from 'path';
 import mime from 'mime';
 import Bluebird from 'bluebird';
 
-// import { handleError } from './handleError';
-
 export class Receiver {
   constructor(opts = {}) {
     this.options = Object.assign({}, opts);


### PR DESCRIPTION
Some users (c.f., me) want the get and post routes for the upload to add to a different plugin, instead of all-in-one.

So now the hapiPlugin also includes `getRoute(receiver)` and `postRoute(receiver)`, each of which return a hapi route block. Note  both require a configured receiver instance to be passed in. Those route blocks can then later be adjusted through normal accessors before being passed to `server.route`.